### PR TITLE
SSHD Check Pass log parser

### DIFF
--- a/Ubuntu-SSH-Log-Parser/sshd_check_pass/README.md
+++ b/Ubuntu-SSH-Log-Parser/sshd_check_pass/README.md
@@ -1,0 +1,62 @@
+# SSHD Check Pass Log Parser
+
+This Vector configuration parses Ubuntu's auth.log entries specifically for PAM (Pluggable Authentication Modules) password authentication events.
+
+## Overview
+
+The configuration detects and parses log entries when PAM authentication checks occur in the SSH server. It extracts relevant information such as timestamp, hostname, program details, and authentication information.
+
+## Input Format
+
+The parser expects syslog messages in the following format:
+
+```
+Aug 15 14:23:45 ubuntu-server sshd[12345]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.1.100
+```
+
+## Configuration Details
+
+The configuration uses Vector's parsing capabilities to:
+1. Match the syslog pattern for PAM authentication events
+2. Extract timestamp, hostname, and program information
+3. Parse the PAM module, activity type, and authentication details
+4. Structure the data into a standardized JSON format
+
+### Sample Output
+
+The parsed log entry will be written to `vector_parsed_pam.json` in the following format:
+
+```json
+{
+  "timestamp": "Aug 15 14:23:45",
+  "hostname": "ubuntu-server",
+  "program": "sshd",
+  "appname": "sshd",
+  "pid": 12345,
+  "pam_module": "pam_unix",
+  "pam_activity": "auth",
+  "reason": "authentication failure",
+  "event_type": "pam_unix_check_pass"
+}
+```
+
+This JSON output provides a structured representation of PAM authentication events, making it easier to analyze and process the log data.
+
+## Usage
+
+1. Ensure Vector is properly installed on your system
+2. Copy the configuration to your Vector configuration directory
+3. Update the input and output paths as needed
+4. Restart Vector to apply the changes
+
+## Requirements
+
+- Vector v0.44 or higher
+- System with SSH server logs
+- Write permissions for output directory
+
+## Notes
+
+- The parser specifically handles PAM authentication events
+- Make sure your log format matches the expected input format
+- Adjust file paths in the configuration according to your system

--- a/Ubuntu-SSH-Log-Parser/sshd_check_pass/auth.log
+++ b/Ubuntu-SSH-Log-Parser/sshd_check_pass/auth.log
@@ -1,0 +1,1 @@
+Feb 20 10:48:24 mihir-ubuntu sshd[15112]: pam_unix(sshd:auth): check pass; user unknown

--- a/Ubuntu-SSH-Log-Parser/sshd_check_pass/vector.yaml
+++ b/Ubuntu-SSH-Log-Parser/sshd_check_pass/vector.yaml
@@ -1,0 +1,39 @@
+data_dir: "/var/lib/vector"
+
+sources:
+  auth_logs:
+    type: file
+    include:
+      - "auth.log"
+    start_at_beginning: true
+
+transforms:
+  parse_pam_unix:
+    type: remap
+    inputs:
+      - "auth_logs"
+    source: |
+      parsed = parse_regex!(.message, r'^(?P<timestamp>\w+\s+\d+\s+\d+:\d+:\d+)\s+(?P<hostname>\S+)\s+(?P<program>\S+)\[(?P<pid>\d+)\]:\s+(?P<pam_module>\S+)\((?P<pam_details>[^)]+)\):\s+(?P<msg>.+)$')
+      if parsed != null {
+        .timestamp   = parsed.timestamp
+        .hostname    = parsed.hostname
+        .program     = parsed.program
+        .appname     = parsed.program
+        .pid         = to_int!(parsed.pid)
+        .pam_module  = parsed.pam_module
+        .pam_activity = parsed.pam_details
+        .reason         = parsed.msg
+        .event_type  = "pam_unix_check_pass"
+      } else {
+        log("Failed to parse pam_unix log", level: "error")
+      }
+      del(.file)
+
+sinks:
+  output:
+    type: file
+    inputs:
+      - "parse_pam_unix"
+    path: "vector_parsed_log.json"
+    encoding:
+      codec: json

--- a/Ubuntu-SSH-Log-Parser/sshd_check_pass/vector_parsed_log.json
+++ b/Ubuntu-SSH-Log-Parser/sshd_check_pass/vector_parsed_log.json
@@ -1,0 +1,1 @@
+{"appname":"sshd","event_type":"pam_unix_check_pass","host":"localhost.localdomain","hostname":"mihir-ubuntu","message":"Feb 20 10:48:24 mihir-ubuntu sshd[15112]: pam_unix(sshd:auth): check pass; user unknown","pam_activity":"sshd:auth","pam_module":"pam_unix","pid":15112,"program":"sshd","reason":"check pass; user unknown","source_type":"file","timestamp":"Feb 20 10:48:24"}


### PR DESCRIPTION
# SSHD Check Pass Log Parser

This Vector configuration parses Ubuntu's auth.log entries specifically for PAM (Pluggable Authentication Modules) password authentication events.

## Overview

The configuration detects and parses log entries when PAM authentication checks occur in the SSH server. It extracts relevant information such as timestamp, hostname, program details, and authentication information.

## Input Format

The parser expects syslog messages in the following format:

```
Aug 15 14:23:45 ubuntu-server sshd[12345]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.1.100
```

## Configuration Details

The configuration uses Vector's parsing capabilities to:
1. Match the syslog pattern for PAM authentication events
2. Extract timestamp, hostname, and program information
3. Parse the PAM module, activity type, and authentication details
4. Structure the data into a standardized JSON format

### Sample Output

The parsed log entry will be written to `vector_parsed_pam.json` in the following format:

```json
{
  "timestamp": "Aug 15 14:23:45",
  "hostname": "ubuntu-server",
  "program": "sshd",
  "appname": "sshd",
  "pid": 12345,
  "pam_module": "pam_unix",
  "pam_activity": "auth",
  "reason": "authentication failure",
  "event_type": "pam_unix_check_pass"
}
```

This JSON output provides a structured representation of PAM authentication events, making it easier to analyze and process the log data.

## Usage

1. Ensure Vector is properly installed on your system
2. Copy the configuration to your Vector configuration directory
3. Update the input and output paths as needed
4. Restart Vector to apply the changes

## Requirements

- Vector v0.44 or higher
- System with SSH server logs
- Write permissions for output directory

## Notes

- The parser specifically handles PAM authentication events
- Make sure your log format matches the expected input format
- Adjust file paths in the configuration according to your system