### PR TITLE
SSHD Terminating Signal Parser configuration

### DIFF
--- a/Ubuntu-SSH-Log-Parser/sshd_terminating/README.md
+++ b/Ubuntu-SSH-Log-Parser/sshd_terminating/README.md
@@ -1,0 +1,61 @@
+# SSHD Terminating Signal Parser
+
+This Vector configuration parses SSH termination events when the SSH daemon receives signals to terminate or restart.
+
+## Overview
+
+The configuration detects and parses log entries when the SSH daemon receives system signals. It extracts relevant information such as timestamp, hostname, program details, and signal information.
+
+## Input Format
+
+The parser expects syslog messages in the following format:
+
+```
+Nov 15 11:22:33 ubuntu-server sshd[1234]: Received signal 15; terminating.
+```
+
+## Configuration Details
+
+The configuration uses Vector's parsing capabilities to:
+1. Match the syslog pattern for SSH signal reception events
+2. Extract timestamp, hostname, and program information
+3. Parse the signal number and termination message
+4. Structure the data into a standardized JSON format
+
+### Sample Output
+
+The parsed log entry will be written to `vector_parsed_log.json` in the following format:
+
+```json
+{
+  "timestamp": "Nov 15 11:22:33",
+  "hostname": "ubuntu-server",
+  "program": "sshd",
+  "appname": "sshd",
+  "pid": 1234,
+  "signal": 15,
+  "reason": "terminating",
+  "event_type": "ssh_signal"
+}
+```
+
+This JSON output provides a structured representation of SSH termination events, making it easier to analyze and process the log data.
+
+## Usage
+
+1. Ensure Vector is properly installed on your system
+2. Copy the configuration to your Vector configuration directory
+3. Update the input and output paths as needed
+4. Restart Vector to apply the changes
+
+## Requirements
+
+- Vector v0.44 or higher
+- System with SSH server logs
+- Write permissions for output directory
+
+## Notes
+
+- The parser specifically handles SSH daemon signal events
+- Make sure your log format matches the expected input format
+- Adjust file paths in the configuration according to your system

--- a/Ubuntu-SSH-Log-Parser/sshd_terminating/auth.log
+++ b/Ubuntu-SSH-Log-Parser/sshd_terminating/auth.log
@@ -1,0 +1,1 @@
+Feb 20 10:46:08 mihir-ubuntu sshd[2998]: Received signal 15; terminating.

--- a/Ubuntu-SSH-Log-Parser/sshd_terminating/vector.yaml
+++ b/Ubuntu-SSH-Log-Parser/sshd_terminating/vector.yaml
@@ -1,0 +1,38 @@
+data_dir: "/var/lib/vector"
+
+sources:
+  ssh_logs:
+    type: "file"
+    include:
+      - "auth.log"
+    start_at_beginning: true
+
+transforms:
+  parse_ssh:
+    type: "remap"
+    inputs:
+      - "ssh_logs"
+    source: |
+      parsed = parse_regex!(.message, r'^(?P<timestamp>\w+\s+\d+\s+\d+:\d+:\d+)\s+(?P<hostname>\S+)\s+(?P<program>\S+)\[(?P<pid>\d+)\]:\s+Received signal (?P<signal>\d+); (?P<msg>.+)$')
+      if parsed != null {
+        .timestamp = parsed.timestamp
+        .hostname = parsed.hostname
+        .program = parsed.program
+        .appname = parsed.program
+        .pid = to_int!(parsed.pid)
+        .signal = to_int!(parsed.signal)
+        .reason = parsed.msg
+        .event_type = "ssh_signal"
+      } else {
+        log("Failed to parse log", level: "error")
+      }
+      del(.file)
+
+sinks:
+  parsed_syslog:
+    type: "file"
+    inputs:
+      - parse_ssh
+    path: "vector_parsed_log.json"
+    encoding:
+      codec: "json"

--- a/Ubuntu-SSH-Log-Parser/sshd_terminating/vector_parsed_log.json
+++ b/Ubuntu-SSH-Log-Parser/sshd_terminating/vector_parsed_log.json
@@ -1,0 +1,1 @@
+{"appname":"sshd","event_type":"ssh_signal","host":"localhost.localdomain","hostname":"mihir-ubuntu","message":"Feb 20 10:46:08 mihir-ubuntu sshd[2998]: Received signal 15; terminating.","pid":2998,"program":"sshd","reason":"terminating.","signal":15,"source_type":"file","timestamp":"Feb 20 10:46:08"}


### PR DESCRIPTION
### **Merge Request: SSH Termination Log Parser**  

#### **Description:**  
This merge request introduces a **Vector-based log parser** for **SSH daemon termination events**, allowing structured JSON output for easier monitoring and troubleshooting of SSH shutdown signals.  

#### **Changes Included:**  
- **Added `README.md`** with parser setup and usage details.  
- **Included a sample `auth.log` entry** for termination signals.  
- **Created `vector.yaml`** to parse SSH termination events.  
- **Generated `vector_parsed_log.json`** for structured output.  

#### **Features Implemented:**  
- **Monitors `/var/log/auth.log`** for SSH termination events.  
- **Extracts key log details**, including:  
  -  **Timestamp**  
  -  **Hostname**  
  -  **Program (sshd)**  
  -  **Process ID (PID)**  
  -  **Signal Number (e.g., `15`)**  
  -  **Termination Reason (`terminating`)**  
  -  **Event Type: `ssh_signal`**  
- **Parses and structures logs** into a JSON format.  
- **Stores structured log data** in `vector_parsed_log.json`.  

#### **How to Test:**  
1. **Ensure Vector is installed** on your system.  
2. **Update input log file path** in `vector.yaml` if necessary.  
3. **Validate the configuration:**  
   ```sh
   vector validate
   ```  
4. **Run Vector:**  
   ```sh
   vector --config vector.yaml
   ```  
5. **Check `vector_parsed_log.json`** for structured output.  

#### **Sample Input Log (`auth.log`):**  
```
Feb 20 10:46:08 mihir-ubuntu sshd[2998]: Received signal 15; terminating.
```  

#### **Sample Parsed Output (`vector_parsed_log.json`):**  
```json
{
  "timestamp": "Feb 20 10:46:08",
  "hostname": "mihir-ubuntu",
  "program": "sshd",
  "appname": "sshd",
  "pid": 2998,
  "signal": 15,
  "reason": "terminating",
  "event_type": "ssh_signal"
}
```  

#### **Output Explanation:**  
- **Event Type:** `"ssh_signal"` categorizes the log entry.  
- **Context Details:** Extracts **signal number, PID, hostname, and termination reason**.  
- **Original Message:** Stored for reference and debugging.  

#### **Why This Matters?**  
This implementation helps **monitor SSH service stability**, track **unexpected terminations**, and **troubleshoot SSH daemon restarts**. 